### PR TITLE
added update checker for latest release of dum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,6 @@ log = "0.4.14"
 env_logger = "0.9.0"
 path-absolutize = "3.0.11"
 anyhow = "1.0.52"
-ureq = { version = "2.4.0", features = ["json"] }
 serde = { version = "1.0.136", features = ["derive"] }
+reqwest = { version = "0.11.10", features = ["json"] }
+tokio = { version = "1.17.0", features = ["rt-multi-thread","macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ log = "0.4.14"
 env_logger = "0.9.0"
 path-absolutize = "3.0.11"
 anyhow = "1.0.52"
+ureq = { version = "2.4.0", features = ["json"] }
+serde = { version = "1.0.136", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,13 +2,15 @@ mod args;
 mod install;
 mod prompt;
 mod run;
+mod uchecker;
 
 use std::env;
+use uchecker::update_check;
 
 fn main() {
     env_logger::init();
     prompt::handle_ctrlc();
-
+    let _ = update_check();
     let args_vec: Vec<String> = env::args().collect();
     let args = args::parse_args(&args_vec[1..]);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,11 @@ mod uchecker;
 
 use std::env;
 use uchecker::update_check;
-
-fn main() {
+#[tokio::main]
+async fn main() {
     env_logger::init();
     prompt::handle_ctrlc();
-    let _ = update_check();
+    let _ = update_check().await;
     let args_vec: Vec<String> = env::args().collect();
     let args = args::parse_args(&args_vec[1..]);
 

--- a/src/uchecker.rs
+++ b/src/uchecker.rs
@@ -1,0 +1,21 @@
+use ansi_term::Color::{Green, Red};
+use serde::Deserialize;
+#[derive(Deserialize)]
+struct Answer {
+    tag_name: String,
+}
+
+pub fn update_check() -> Result<(), ureq::Error> {
+    let answer: Answer = ureq::get("https://api.github.com/repos/egoist/dum/releases/latest")
+        .call()?
+        .into_json()?;
+    let version = answer.tag_name.replace("v", "");
+    if env!("CARGO_PKG_VERSION") != version {
+        println!(
+            "{} {}",
+            Red.normal().paint("There is a new version of dum:"),
+            Green.normal().paint(version)
+        );
+    }
+    Ok(())
+}

--- a/src/uchecker.rs
+++ b/src/uchecker.rs
@@ -19,7 +19,7 @@ pub async fn update_check() -> Result<(), reqwest::Error> {
         .json::<Answer>()
         .await?;
     let version = answer.tag_name.replace('v', "");
-    if env!("CARGO_PKG_VERSION") == version {
+    if env!("CARGO_PKG_VERSION") != version {
         println!(
             "{} {}",
             Red.normal().paint("There is a new version of dum:"),

--- a/src/uchecker.rs
+++ b/src/uchecker.rs
@@ -1,16 +1,25 @@
 use ansi_term::Color::{Green, Red};
 use serde::Deserialize;
+
+static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
+
 #[derive(Deserialize)]
 struct Answer {
     tag_name: String,
 }
 
-pub fn update_check() -> Result<(), ureq::Error> {
-    let answer: Answer = ureq::get("https://api.github.com/repos/egoist/dum/releases/latest")
-        .call()?
-        .into_json()?;
-    let version = answer.tag_name.replace("v", "");
-    if env!("CARGO_PKG_VERSION") != version {
+pub async fn update_check() -> Result<(), reqwest::Error> {
+    let client = reqwest::Client::builder()
+        .user_agent(APP_USER_AGENT)
+        .build()?;
+    let answer = client
+        .get("https://api.github.com/repos/egoist/dum/releases/latest")
+        .send()
+        .await?
+        .json::<Answer>()
+        .await?;
+    let version = answer.tag_name.replace('v', "");
+    if env!("CARGO_PKG_VERSION") == version {
         println!(
             "{} {}",
             Red.normal().paint("There is a new version of dum:"),


### PR DESCRIPTION
closes #28

The checker uses a get request to GitHub releases to find the latest version from its tag. If using GitHub is not ideal, other API's can be used instead such as crates.io .

This change required two additional libraries to make the request and deserialize it. Therefore `ureq` and `serde` were added to Cargo.toml . 


If other options are preferred, I would be more than happy to apply them.  
